### PR TITLE
Fix ES2015 style default exports

### DIFF
--- a/src/StaticReactSource.js
+++ b/src/StaticReactSource.js
@@ -54,7 +54,9 @@ StaticReactSource.prototype.source = function() {
 
   var script = compile();
   var context = createContext();
-  var reactClass = script.runInContext(context);
+  var result = script.runInContext(context);
+  // exports.default or module.exports
+  var reactClass = result.default || result;
   var Component = React.createFactory(reactClass);
   var html = ReactDOMServer.renderToStaticMarkup(Component());
 


### PR DESCRIPTION
Fixes the issue with ES2015 style default exports.

Babel 5 used to have an interop feature (last seen here http://babeljs.io/docs/usage/modules/#interop):

``` javascript
exports["default"] = test;
module.exports = exports["default"];
```

Now, the compiled code only contains a `exports.default = MyReactClass` statement. Thus, when interpreting the source chunk inside StaticReactSource the desired React class function is either returned directly (module.exports) or we get an object with the function set as the `default` property (exports.default).
